### PR TITLE
Bug 1618575 - Add a view to searchengine-devtools where you can see which region/locales a search engine is deployed to 

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -21,6 +21,11 @@
         <label for="locale-select">Locale</label>
         <select id="locale-select" multiple size="4"></select>
       </div>
+
+      <div>
+        <label for="distro-id">Distribution ID</label>
+        <input id="distro-id" type="text" />
+      </div>
     </div>
 
     <div id="server-settings">

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -122,8 +122,12 @@
             </div>
           </div>
           <div>
-            <label for="engine-id">Engine Id</label>
+            <label for="engine-id">Engine Id (reqd)</label>
             <input id="engine-id" type="text" />
+          </div>
+          <div>
+            <label for="engine-telemetry-id">Telemetry Id</label>
+            <input id="engine-telemetry-id" type="text" />
           </div>
           <div>
             <label for="by-engine-progress">Progress:</label>

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -126,7 +126,8 @@
             <input id="engine-id" type="text" />
           </div>
           <div>
-            <label id="by-engine-progress"></label>
+            <label for="by-engine-progress">Progress:</label>
+            <progress id="by-engine-progress" max="100" value="0"> 0% </progress>
           </div>
         </fieldset>
 

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -103,7 +103,35 @@
         </p>
       </div>
       <div id="by-engine-tab">
-        <p>By Engine</p>
+        <fieldset id="engine-selection">
+          <div>
+            <div>
+              <input type="radio"
+                     id="locale-by-engine"
+                     name="by-engine-radio"
+                     value="locale"
+                     checked/>
+              <label for="locale-by-engine">By Locale</label>
+            </div>
+            <div>
+              <input type="radio"
+                     id="region-by-engine"
+                     name="by-engine-radio"
+                     value="region"/>
+              <label for="region-by-engine">By Region</label>
+            </div>
+          </div>
+          <div>
+            <label for="engine-id">Engine Id</label>
+            <input id="engine-id" type="text" />
+          </div>
+          <div>
+            <label id="by-engine-progress"></label>
+          </div>
+        </fieldset>
+
+        <div id="locale-region-results">
+        </div>
       </div>
     </div>
   </section>

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -10,24 +10,8 @@
 
 <body class="loading">
   <form>
-  <section id="settings">
-    <div id="locale-region-settings">
-      <div>
-        <label for="region-select">Region</label>
-        <select id="region-select" multiple size="4"></select>
-      </div>
-
-      <div>
-        <label for="locale-select">Locale</label>
-        <select id="locale-select" multiple size="4"></select>
-      </div>
-
-      <div>
-        <label for="distro-id">Distribution ID</label>
-        <input id="distro-id" type="text" />
-      </div>
-    </div>
-
+  <fieldset id="settings">
+    <legend>Configuration Settings</legend>
     <div id="server-settings">
       <table>
         <tr>
@@ -78,25 +62,50 @@
         <button id="reload-page">Clear Cache & Reload Page</button>
       </div>
     </div>
+    <div id="configuration">
+      <textarea id="config"></textarea>
+      <button id="reload-engines">Use this Schema and Reload Engines</button>
+    </div>
 
-  </section>
+  </fieldset>
 
   <section id="engines">
-    <div id="engines-table">
+    <div id="tabs">
+      <button id="by-locales">Engines by locale/region</button>
+      <button id="by-engine">Locale/region by Engine</button>
     </div>
-    <p>Default engine is the one listed at index 1. Private Browsing Engine:
-      <span id="private-browsing-engine"></span>
-      <br />
-      Sort is approximate: Sort is by default engine, orderHint and then alphabetical by display name.
-    </p>
-  </section>
 
-  <section id="configuration">
-    <header>
-      <h2>Configuration:</h2>
-      <button id="reload-engines">Reload Engines</button>
-    </header>
-    <textarea id="config"></textarea>
+    <div id="tab-contents">
+      <div id="by-locales-tab">
+        <fieldset id="locale-region-settings">
+          <div>
+            <label for="region-select">Region</label>
+            <select id="region-select" multiple size="4"></select>
+          </div>
+
+          <div>
+            <label for="locale-select">Locale</label>
+            <select id="locale-select" multiple size="4"></select>
+          </div>
+
+          <div>
+            <label for="distro-id">Distribution ID</label>
+            <input id="distro-id" type="text" />
+          </div>
+        </fieldset>
+
+        <div id="engines-table">
+        </div>
+        <p>Default engine is the one listed at index 1. Private Browsing Engine:
+          <span id="private-browsing-engine"></span>
+          <br />
+          Sort is approximate: Sort is by default engine, orderHint and then alphabetical by display name.
+        </p>
+      </div>
+      <div id="by-engine-tab">
+        <p>By Engine</p>
+      </div>
+    </div>
   </section>
 </form>
 

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -169,7 +169,7 @@ async function calculateLocaleRegions(event) {
   if (!engineId) {
     return;
   }
-  $("#by-engine-progress").textContent = "Progress: 0%";
+  $("#by-engine-progress").value = 0;
   $("#locale-region-results").innerHTML = "";
 
   const allLocales = await getLocales();
@@ -207,7 +207,9 @@ async function calculateLocaleRegions(event) {
     }
     results.set(item, itemResults);
     count++;
-    $("#by-engine-progress").textContent = getProgressString(count, byLength);
+    const percent = Math.round((count * 100) / byLength);
+    $("#by-engine-progress").value = percent;
+    $("#by-engine-progress").textContent = `${percent}%`;
   }
 
   let list = `<div>${byLocale ? "Locales" : "Regions"}</div><div>${

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -91,6 +91,7 @@ async function initUI() {
   $("#locale-select").addEventListener("change", reloadEngines);
   $("#distro-id").addEventListener("input", reloadEngines);
   $("#engine-id").addEventListener("change", calculateLocaleRegions);
+  $("#engine-telemetry-id").addEventListener("change", calculateLocaleRegions);
   $("#locale-by-engine").addEventListener("change", calculateLocaleRegions);
   $("#region-by-engine").addEventListener("change", calculateLocaleRegions);
 
@@ -194,6 +195,8 @@ async function doLocaleRegionCalculation(engineId, abortObj) {
   $("#by-engine-progress").value = 0;
   $("#locale-region-results").innerHTML = "";
 
+  const telemetryId = $("#engine-telemetry-id").value;
+
   const allLocales = await getLocales();
   const allRegions = await getRegions();
 
@@ -223,7 +226,13 @@ async function doLocaleRegionCalculation(engineId, abortObj) {
       );
       for (let engine of engines) {
         if (engine.webExtension.id.startsWith(engineId)) {
-          itemResults.add(subItem);
+          if (telemetryId) {
+            if (engine.telemetryId == telemetryId) {
+              itemResults.add(subItem);
+            }
+          } else {
+            itemResults.add(subItem);
+          }
         }
       }
       if (abortObj.abort) {

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -38,11 +38,13 @@ async function main() {
 async function loadEngines() {
   let locale = $("#locale-select").value;
   let region = $("#region-select").value;
+  let distroID = $("#distro-id").value;
   let config = "data:application/json;charset=UTF-8," + $("#config").value;
   let { engines, private } = await searchengines.getEngines(
     config,
     locale,
-    region
+    region,
+    distroID
   );
 
   const list = engines.map(
@@ -87,6 +89,7 @@ async function initUI() {
 
   $("#region-select").addEventListener("change", reloadEngines);
   $("#locale-select").addEventListener("change", reloadEngines);
+  $("#distro-id").addEventListener("change", reloadEngines);
 
   $("#reload-engines").addEventListener("click", reloadEngines);
   $("#reload-page").addEventListener("click", reloadPage);

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -89,18 +89,39 @@ async function initUI() {
 
   $("#region-select").addEventListener("change", reloadEngines);
   $("#locale-select").addEventListener("change", reloadEngines);
-  $("#distro-id").addEventListener("change", reloadEngines);
+  $("#distro-id").addEventListener("input", reloadEngines);
 
   $("#reload-engines").addEventListener("click", reloadEngines);
   $("#reload-page").addEventListener("click", reloadPage);
 
   $("#engines-table").addEventListener("click", showConfig);
+
+  $("#by-locales").setAttribute("selected", true);
+  $("#by-locales-tab").setAttribute("selected", true);
+
+  $("#by-locales").addEventListener("click", changeTabs);
+  $("#by-engine").addEventListener("click", changeTabs);
+}
+
+async function changeTabs(event) {
+  event.preventDefault();
+  if (event.target.id == "by-locales") {
+    $("#by-locales").setAttribute("selected", true);
+    $("#by-engine").removeAttribute("selected");
+    $("#by-locales-tab").setAttribute("selected", true);
+    $("#by-engine-tab").removeAttribute("selected");
+  } else {
+    $("#by-locales").removeAttribute("selected");
+    $("#by-engine").setAttribute("selected", true);
+    $("#by-locales-tab").removeAttribute("selected");
+    $("#by-engine-tab").setAttribute("selected", true);
+  }
 }
 
 async function loadConfiguration() {
   const URL = ENGINES_URLS[$('input[name="server-radio"]:checked').value];
   let config = JSON.parse(await fetchCached(URL, ONE_DAY));
-  $("#configuration textarea").value = JSON.stringify(config, null, 2);
+  $("#config").value = JSON.stringify(config, null, 2);
 }
 
 async function showConfig(e) {

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -81,11 +81,11 @@ h1, h2, h3, h4 {
 #by-engine, #by-locales {
   margin: 0;
   padding: 0;
-  background-color: transparent;
+  background-color: var(--in-content-button-background);
 }
 
 #by-engine[selected], #by-locales[selected] {
-  background-color: var(--in-content-button-background);
+  background-color: transparent;
 }
 
 #by-engine:hover, #by-locales:hover {
@@ -193,4 +193,34 @@ h1, h2, h3, h4 {
 #reload-div > button {
   margin-right: auto;
   margin-left: auto;
+}
+
+#engine-selection {
+  display: grid;
+  grid: auto-flow / max-content 1fr 1fr;
+  align-items: center;
+}
+
+#engine-selection > div {
+  padding: 0 0.5em;
+}
+
+#locale-region-results {
+  display: grid;
+  grid: auto-flow / max-content 1fr;
+}
+
+#locale-region-results > div {
+  padding: .3em 1em;
+}
+
+#locale-region-results > div:nth-child(-n+2) {
+  font-weight: bold;
+  text-align: center;
+  padding-bottom: .5em;
+}
+
+#locale-region-results > div:nth-child(2n+3):nth-child(4n+3),
+#locale-region-results > div:nth-child(2n+4):nth-child(4n+4) {
+  background: var(--in-content-box-background-odd);
 }

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -171,6 +171,10 @@ h1, h2, h3, h4 {
   text-overflow: ellipsis;
 }
 
+#configuration textarea {
+  line-height: 20px;
+}
+
 #server-settings > table {
   border-collapse: collapse;
 }

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -201,7 +201,7 @@ h1, h2, h3, h4 {
 
 #engine-selection {
   display: grid;
-  grid: auto-flow / max-content 1fr 1fr;
+  grid: auto-flow / max-content 1fr 1fr 1fr;
   align-items: center;
 }
 

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -17,7 +17,7 @@ html, body {
 }
 
 body {
-  margin: 40px;
+  margin: 15px;
   color: var(--in-content-text-color);
 }
 
@@ -38,8 +38,80 @@ h1, h2, h3, h4 {
 }
 
 #settings {
+  display: grid;
+  grid: auto-flow / max-content 1fr;
+}
+
+#settings {
+  padding: 1em 0.5em;
+}
+
+#configuration {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  height: 15em;
+  padding-left: 0.5em;
+}
+
+#config {
+  margin-top: 0;
+  flex: 3;
+}
+
+#reload-engines {
+  width: max-content;
+  margin: auto;
+}
+
+#engines {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+#engines p {
+  color: var(--in-content-deemphasized-text);
+}
+
+#tabs {
+  display: grid;
+  grid: auto-flow / 1fr 1fr;
+}
+
+#by-engine, #by-locales {
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+}
+
+#by-engine[selected], #by-locales[selected] {
+  background-color: var(--in-content-button-background);
+}
+
+#by-engine:hover, #by-locales:hover {
+  background-color: var(--in-content-button-background-hover);
+}
+
+#tab-contents {
+  margin: 1em;
+  /* To stop vertical jumping when going through engine lists */
+  min-height: 32em;
+}
+
+#by-locales-tab, #by-engine-tab {
+  display: none;
+}
+
+#by-locales-tab[selected], #by-engine-tab[selected] {
+  display: block;
+}
+
+#locale-region-settings {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: max-content;
+  margin: 0 auto;
 }
 
 #locale-region-settings div {
@@ -51,9 +123,14 @@ h1, h2, h3, h4 {
   display: block;
 }
 
+#engines {
+  margin: 15px 0px;
+}
+
 #engines-table {
   display: grid;
   grid-template-columns: repeat(5, max-content) auto;
+  padding-top: 1em;
 }
 
 #engines-table > div {
@@ -84,10 +161,6 @@ h1, h2, h3, h4 {
   background: var(--in-content-box-background-odd);
 }
 
-#engines p {
-  color: var(--in-content-deemphasized-text);
-}
-
 #private-browsing-engine {
   color: var(--in-content-text-color);
 }
@@ -96,22 +169,6 @@ h1, h2, h3, h4 {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-#configuration textarea {
-  width: 100%;
-  height: 250px;
-  line-height: 20px;
-}
-
-#locale-region-settings, #settings, #configuration header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-#configuration header h2 {
-  margin: 0;
 }
 
 #server-settings > table {

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -21,10 +21,10 @@ async function getCurrentLocale() {
   return Services.locale.appLocaleAsBCP47;
 }
 
-async function getEngines(configUrl, locale, region) {
+async function getEngines(configUrl, locale, region, distroID) {
   let engineSelector = new SearchEngineSelector();
   await engineSelector.init(configUrl);
-  return engineSelector.fetchEngineConfiguration(locale, region);
+  return engineSelector.fetchEngineConfiguration(locale, region, "", distroID);
 }
 
 var searchengines = class extends ExtensionAPI {

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -41,6 +41,10 @@
           "name": "region",
           "description": "The users region",
           "type": "string"
+        }, {
+          "name": "distroID",
+          "description": "The user's distribution",
+          "type": "string"
         }]
       }
     ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "dependencies": {


### PR DESCRIPTION
This adds a review where you can see which region/locales a search engine is deployed to.

I think this is probably good enough for a first version, though I'm happy to address issues if we think we need to.