### PR TITLE
Bug 1622864 - In searchengine-devtools, always show a telemetry id, not 'undefined'.

### DIFF
--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -39,9 +39,8 @@ async function loadEngines() {
   let locale = $("#locale-select").value;
   let region = $("#region-select").value;
   let distroID = $("#distro-id").value;
-  let config = "data:application/json;charset=UTF-8," + $("#config").value;
   let { engines, private } = await searchengines.getEngines(
-    config,
+    $("#config").value,
     locale,
     region,
     distroID
@@ -220,9 +219,7 @@ async function doLocaleRegionCalculation(engineId, abortObj) {
   const byLength = allBy.length;
   // Pre-filter the config for just the engine id to reduce the amount of
   // processing to do.
-  const config =
-    "data:application/json;charset=UTF-8," +
-    filterConfig($("#config").value, engineId);
+  const config = filterConfig($("#config").value, engineId);
 
   let count = 0;
   const results = new Map();

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -47,12 +47,24 @@ async function loadEngines() {
     distroID
   );
 
+  function getTelemetryId(e) {
+    // Based on SearchService.getEngineParams().
+    let telemetryId = e.telemetryId;
+    if (!telemetryId) {
+      telemetryId = e.webExtension.id.split("@")[0];
+      if (e.webExtension.locale != "default") {
+        telemetryId += "-" + e.webExtension.locale;
+      }
+    }
+    return telemetryId;
+  }
+
   const list = engines.map(
     (e, i) => `
     <div data-id="${e.webExtension.id}">${i + 1}</div>
     <div data-id="${e.webExtension.id}">${e.webExtension.id}</div>
     <div data-id="${e.webExtension.id}">${e.webExtension.locale}</div>
-    <div data-id="${e.webExtension.id}">${e.telemetryId}</div>
+    <div data-id="${e.webExtension.id}">${getTelemetryId(e)}</div>
     <div data-id="${e.webExtension.id}">${e.orderHint}</div>
     <div data-id="${e.webExtension.id}" class="params">
       ${e.params ? JSON.stringify(e.params) : ""}

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -27,8 +27,7 @@ async function getEngines(configUrl, locale, region, distroID) {
   let engineSelector = new SearchEngineSelector();
   if (!("init" in engineSelector)) {
     engineSelector.getEngineConfiguration = async () => {
-      const response = await fetch(configUrl);
-      const result = (await response.json()).data;
+      const result = JSON.parse(configUrl).data;
       engineSelector._configuration = result;
       return result;
     };

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,6 +20,12 @@
     "browser_style": true
   },
 
+  "permissions": [
+    "https://firefox.settings.services.mozilla.com/*",
+    "https://settings.stage.mozaws.net/*",
+    "https://hg.mozilla.org/"
+  ],
+
   "icons": {
     "48": "icon.png",
     "96": "icon.png"


### PR DESCRIPTION
The permissions addition to the manifest seems to get around some of the CORS request issues I've been seeing.